### PR TITLE
#37 Implemented invalidate cloudfront cache

### DIFF
--- a/modules/terrahouse_aws/outputs.tf
+++ b/modules/terrahouse_aws/outputs.tf
@@ -7,3 +7,8 @@ output "website_endpoint" {
   description = "S3 Static Website hosting endpoint"
   value = aws_s3_bucket_website_configuration.website_configuration.website_endpoint
 }
+
+output "cloudfront_url" {
+  description = "CloudFront Distribution domain name"
+  value = aws_cloudfront_distribution.s3_distribution.domain_name
+}

--- a/modules/terrahouse_aws/resource_cdn.tf
+++ b/modules/terrahouse_aws/resource_cdn.tf
@@ -58,3 +58,14 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     cloudfront_default_certificate = true
   }
 }
+
+resource "terraform_data" "invalidate_cache" {
+  triggers_replace = terraform_data.content_version.output
+  provisioner "local-exec" {
+    command = <<EOT
+aws cloudfront create-invalidation \
+--distribution-id "${aws_cloudfront_distribution.s3_distribution.id}" \
+--paths "/*" 
+    EOT
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "s3_website_endpoint" {
   description = "S3 Static Website hosting endpoint"
   value = module.terrahouse_aws.website_endpoint
 }
+
+output "cloudfront_url" {
+  description = "CloudFront Distribution domain name"
+  value = module.terrahouse_aws.cloudfront_url
+}


### PR DESCRIPTION
- [x] Use terraform_data resource to trigger a local-exec provisioner
- [x] Use heredoc in local-exec to run an AWS CLI command to invalidate CloudFront distribution cache
- [x] Update documentation